### PR TITLE
feat(api): implementado silent refresh para renovacion transparente d…

### DIFF
--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,37 +1,62 @@
 import { storage } from '../utils/storage.js';
+import { API_URL } from '../config/constants.js';
 
-/**
- * Wrapper personalizado de fetch para centralizar la seguridad
- * @param {string} endpoint - La URL relativa (ej: /tasks)
- * @param {object} options - Opciones normales de fetch (method, body, etc)
- */
+let isRefreshing = false; // Bandera para evitar bucles infinitos
+
 export async function senaFetch(url, options = {}) {
-    // 1. Obtener el token del gestor de persistencia
-    const token = storage.getAccessToken();
+    let token = storage.getAccessToken();
 
-    // 2. Configurar los encabezados por defecto
-    const defaultHeaders = {
-        "Content-Type": "application/json",
-    };
+    const defaultHeaders = { "Content-Type": "application/json" };
+    if (token) defaultHeaders["Authorization"] = `Bearer ${token}`;
 
-    // 3. Si hay token, lo inyectamos automáticamente
-    if (token) {
-        defaultHeaders["Authorization"] = `Bearer ${token}`;
-    }
-
-    // 4. Combinar con los headers que vengan en las opciones
     const config = {
         ...options,
-        headers: {
-            ...defaultHeaders,
-            ...options.headers
-        }
+        headers: { ...defaultHeaders, ...options.headers }
     };
 
-    // 5. Ejecutar la petición
-    const response = await fetch(url, config);
+    // 1. Ejecutamos la petición original
+    let response = await fetch(url, config);
 
-    // Si recibimos un 401 aquí, es un aviso para la siguiente Issue (Refresh Token)
-    // Por ahora, solo retornamos la respuesta
+    // 2. INTERCEPTOR DE SILENT REFRESH: Si el token expiró (401)
+    if (response.status === 401 && !isRefreshing) {
+        console.warn("🔄 Token expirado. Iniciando Silent Refresh...");
+        isRefreshing = true;
+
+        try {
+            const refreshToken = storage.getRefreshToken();
+            if (!refreshToken) throw new Error("No hay refresh token disponible");
+
+            // Solicitamos nuevos tokens a La Bóveda
+            const refreshRes = await fetch(`${API_URL}/auth/refresh`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ refreshToken })
+            });
+
+            if (!refreshRes.ok) throw new Error("Refresh token inválido o expirado");
+
+            const json = await refreshRes.json();
+            
+            // Extraemos los nuevos tokens (adaptado a la estructura de tu backend)
+            const newAccess = json.data?.accessToken || json.token; 
+            const newRefresh = json.data?.refreshToken || json.refreshToken;
+
+            // Guardamos las nuevas llaves
+            storage.setTokens(newAccess, newRefresh);
+            console.log("✅ Silent Refresh Exitoso. Reintentando petición...");
+
+            // 3. MAGIA: Reintentar la petición original con la nueva llave
+            config.headers["Authorization"] = `Bearer ${newAccess}`;
+            response = await fetch(url, config);
+
+        } catch (error) {
+            console.error("🚨 Fallo crítico. Expulsando usuario al Login...", error);
+            storage.clearTokens();
+            window.location.reload(); // Recargamos para que el sistema lo devuelva a la pantalla de ingreso
+        } finally {
+            isRefreshing = false;
+        }
+    }
+
     return response;
 }


### PR DESCRIPTION
## Descripción del Cambio
Se expandió el interceptor `senaFetch` para manejar no solo las peticiones salientes, sino también las respuestas entrantes. Se implementó un mecanismo de **Silent Refresh**: cuando el servidor rechaza una petición con un código HTTP 401 (Unauthorized), el cliente pausa el flujo, solicita de forma transparente un nuevo par de tokens al endpoint `/auth/refresh`, actualiza el Storage Manager y reintenta la petición original. Si el refresh falla, el sistema expulsa al usuario por seguridad.

## Tipo de Cambio
- [x] **feat**: Nueva funcionalidad (Mecanismo de auto-recuperación de sesión).
- [ ] **fix**: Corrección de error.
- [ ] **refactor**: Mejora de código.

## Relación con Tareas
**Vínculo:** Closes #36 

---

## Checklist de Calidad
- [x] **Sincronización:** Rama actualizada con `develop`.
- [x] **Recuperación Exitosa:** Se corrompió el token manualmente y se validó en Network que la secuencia `401 -> /refresh -> 200 (Reintento)` opera a la perfección sin romper la UI.
- [x] **Manejo de Errores:** Se validó que si el Refresh Token es inválido, el sistema purga el almacenamiento local y expulsa al usuario a la pantalla de ingreso.